### PR TITLE
Set up ECR + IAM users, output appropriate files

### DIFF
--- a/aws/ecr.tf
+++ b/aws/ecr.tf
@@ -1,0 +1,19 @@
+resource "aws_iam_user" "hubploy_ecr_user" {
+  name = "${var.cluster_name}-hubploy-ecr-pusher"
+}
+
+resource "aws_iam_user_policy_attachment" "hubploy_ecr_image_pusher_policy_attachment" {
+  user = aws_iam_user.hubploy_ecr_user.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+# FIXME: UHHHHHHHH, WHAT DOES THIS MEAN FOR OUR STATE FILES?!
+# FIXME: WE SHOULD DEFINITELY MAYBE PUT A PGP KEY IN HERE
+resource "aws_iam_access_key" "hubploy_ecr_user_secret_key" {
+  user = aws_iam_user.hubploy_ecr_user.name
+}
+
+# FIXME: Support multiple images here
+resource "aws_ecr_repository" "primary_user_image" {
+  name                 = "${var.cluster_name}-user-image"
+}

--- a/aws/file-output.tf
+++ b/aws/file-output.tf
@@ -1,0 +1,40 @@
+resource "local_file" "hubploy_ecr_user_creds" {
+  filename = "aws-ecr-creds.cfg"
+  content = <<EOF
+[default]
+aws_access_key_id = ${aws_iam_access_key.hubploy_ecr_user_secret_key.id}
+aws_secret_access_key = ${aws_iam_access_key.hubploy_ecr_user_secret_key.secret}
+EOF
+}
+
+resource "local_file" "hubploy_eks_user_creds" {
+  filename = "aws-eks-creds.cfg"
+  content = <<EOF
+[default]
+aws_access_key_id = ${aws_iam_access_key.hubploy_eks_user_secret_key.id}
+aws_secret_access_key = ${aws_iam_access_key.hubploy_eks_user_secret_key.secret}
+EOF
+}
+
+resource "local_file" "hubploy_yaml" {
+  filename = "hubploy.yaml"
+  content = <<EOF
+images:
+  image_name: ${aws_ecr_repository.primary_user_image.repository_url}
+
+  registry:
+    provider: aws
+    aws:
+      zone: ${var.region}
+      service_key: aws-ecr-creds.cfg
+      project: # FILL ME IN FOR NOW
+
+
+cluster:
+  provider: aws
+  aws:
+      zone: ${var.region}
+      service_key: aws-eks-creds.cfg
+      cluster: ${module.eks.cluster_id}
+EOF
+}

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -34,7 +34,7 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 2.6"
 
-  name                 = var.vpc_name
+  name                 = "${var.cluster_name}-vpc"
   cidr                 = "172.16.0.0/16"
   azs                  = data.aws_availability_zones.available.names
   # We can use private subnets too once https://github.com/aws/containers-roadmap/issues/607

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -6,10 +6,6 @@ variable "cluster_name" {
   default = "test-cluster-change-name"
 }
 
-variable "vpc_name" {
-  default = "vpc-test-cluster-change-name"
-}
-
 variable "map_accounts" {
   description = "Additional AWS account numbers to add to the aws-auth configmap."
   type        = list(string)


### PR DESCRIPTION
This will cause terraform to output:

1. a hubploy.yaml file, to be copied to your deployments/<deployment>
2. aws-ecr-creds.cfg and aws-eks-creds.cfg files, to be copied to
    deployments/<deployment>/secrets

This should have all the perms to get hubploy going!