### PR TITLE
Pin cluster-autoscaler to a known good version

### DIFF
--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -66,6 +66,7 @@ resource "helm_release" "cluster-autoscaler" {
   namespace = "kube-system"
   repository = data.helm_repository.stable.metadata[0].name
   chart = "cluster-autoscaler"
+  version = "7.2.0"
 
   values = [
     file("cluster-autoscaler-values.yml")


### PR DESCRIPTION
By default, 'latest' version is installed. This causes
a large number of problems - for example, breakage
caused by https://github.com/helm/charts/pull/21744#issuecomment-609716005
randomly showed up.
