### PR TITLE
modify IAM role to be prefixed with your cluster name

### DIFF
--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_admin" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v2.6.0"
   create_role                   = true
-  role_name                     = join("-", ["var.cluster_name", "-cluster-autoscaler"])
+  role_name                     = "${module.eks.cluster_id}-cluster-autoscaler"
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler-service-account"]

--- a/aws/autoscaler.tf
+++ b/aws/autoscaler.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_admin" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v2.6.0"
   create_role                   = true
-  role_name                     = "cluster-autoscaler"
+  role_name                     = join("-", ["var.cluster_name", "-cluster-autoscaler"])
   provider_url                  = replace(module.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cluster_autoscaler.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:cluster-autoscaler-service-account"]


### PR DESCRIPTION
when I attempt to run this after the cluster-autoscaler IAM role already exists, I get this error

Error: Kubernetes cluster unreachable

  on autoscaler.tf line 63, in resource "helm_release" "cluster-autoscaler":
  63: resource "helm_release" "cluster-autoscaler" {



Error: Post https://4663658293E17DFB6A45DCF1D286FB08.gr7.us-east-1.eks.amazonaws.com/api/v1/namespaces: dial tcp 54.164.173.32:443: i/o timeout

  on efs.tf line 37, in resource "kubernetes_namespace" "support":
  37: resource "kubernetes_namespace" "support" {



Error: Error creating IAM Role cluster-autoscaler: EntityAlreadyExists: Role with name cluster-autoscaler already exists.
	status code: 409, request id: 853efb00-7b45-4b2d-951b-940d723ccd3b

  on .terraform/modules/iam_assumable_role_admin/terraform-aws-iam-2.6.0/modules/iam-assumable-role-with-oidc/main.tf line 43, in resource "aws_iam_role" "this":
  43: resource "aws_iam_role" "this" {
I was wondering if it would be useful and possible for this to be idempotent, so that it would detect the IAM role exists already and skip creating it. This would allow multiple clusters in one account, our current use case for this is that multiple people are trying to work through setting a cluster up to become familiar with it.

