### PR TITLE
Allow terraform to generate the base role for cluster creation

### DIFF
--- a/aws-creds/iam.tf
+++ b/aws-creds/iam.tf
@@ -216,7 +216,7 @@ data "aws_iam_policy_document" "terraform_iam_policy_source" {
       "eks:DescribeUpdate",
       "eks:*",
       "iam:GetInstanceProfile",
-		  "iam:GetOpenIDConnectProvider",
+      "iam:GetOpenIDConnectProvider",
       "iam:GetPolicy",
       "iam:GetPolicyVersion",
       "iam:GetRole",
@@ -242,14 +242,14 @@ data "aws_iam_policy_document" "terraform_iam_write_policy_source" {
       "iam:AttachRolePolicy",
       "iam:CreateGroup",
       "iam:CreateInstanceProfile",
-  	  "iam:CreateOpenIDConnectProvider",
+      "iam:CreateOpenIDConnectProvider",
       "iam:CreateServiceLinkedRole",
       "iam:CreatePolicy",
       "iam:CreatePolicyVersion",
       "iam:CreateRole",
       "iam:DeleteAccessKey",
       "iam:DeleteInstanceProfile",
-		  "iam:DeleteOpenIDConnectProvider",
+      "iam:DeleteOpenIDConnectProvider",
       "iam:DeletePolicy",
       "iam:DeletePolicyVersion",
       "iam:DeleteRole",
@@ -274,4 +274,16 @@ data "aws_iam_policy_document" "terraform_iam_write_policy_source" {
     ]
     resources = ["*"]
   }
-} 
+}
+
+data "aws_iam_policy_document" "terraform_user_assume_policy" {
+  version = "2012-10-17"
+  statement {
+      effect = "Allow"
+      principals {
+        type = "AWS"
+        identifiers = ["arn:aws:iam::162808325377:root"]
+      }
+      actions = ["sts:AssumeRole"]
+  }
+}

--- a/aws-creds/iam.tf
+++ b/aws-creds/iam.tf
@@ -3,6 +3,9 @@
 # https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/iam-permissions.md
 # Here are a few implementations
 
+variable "region" {
+  default = "us-east-1"
+}
 
 # Create a new user named terraform-bot
 # Create policy in IAM and attach to terraform-bot
@@ -202,13 +205,16 @@ data "aws_iam_policy_document" "terraform_iam_policy_source" {
       "ec2:ModifyLaunchTemplate",
       "ec2:RunInstances",
       "ecr:CreateRepository",
-      "efs:CreateFileSystem",
+      "ecr:DescribeRepositories",
+      "ecr:*",
+      "elasticfilesystem:*",
       "eks:CreateCluster",
       "eks:DeleteCluster",
       "eks:DescribeCluster",
       "eks:ListClusters",
       "eks:UpdateClusterConfig",
       "eks:DescribeUpdate",
+      "eks:*",
       "iam:GetInstanceProfile",
 		  "iam:GetOpenIDConnectProvider",
       "iam:GetPolicy",
@@ -216,7 +222,7 @@ data "aws_iam_policy_document" "terraform_iam_policy_source" {
       "iam:GetRole",
       "iam:GetRolePolicy",
       "iam:List*",
-      "iam:TagRole"
+      "iam:TagRole",
     ]
 
     resources = ["*"]
@@ -234,25 +240,38 @@ data "aws_iam_policy_document" "terraform_iam_write_policy_source" {
     actions = [
       "iam:AddRoleToInstanceProfile",
       "iam:AttachRolePolicy",
+      "iam:CreateGroup",
       "iam:CreateInstanceProfile",
   	  "iam:CreateOpenIDConnectProvider",
       "iam:CreateServiceLinkedRole",
       "iam:CreatePolicy",
       "iam:CreatePolicyVersion",
       "iam:CreateRole",
+      "iam:DeleteAccessKey",
       "iam:DeleteInstanceProfile",
 		  "iam:DeleteOpenIDConnectProvider",
       "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
       "iam:DeleteRole",
       "iam:DeleteRolePolicy",
       "iam:DeleteServiceLinkedRole",
+      "iam:DetachGroupPolicy",
       "iam:DetachRolePolicy",
       "iam:PassRole",
       "iam:PutRolePolicy",
       "iam:RemoveRoleFromInstanceProfile",
-      "iam:UpdateAssumeRolePolicy"
+      "iam:UpdateAssumeRolePolicy",
+      "iam:CreateGroup",
+      "iam:AddUserToGroup",
+      "iam:DeleteGroup",
+      "iam:AttachGroupPolicy",
+      "iam:DeleteUser",
+      "iam:GetGroupPolicy",
+      "iam:GetUser",
+      "iam:CreateUser",
+      "iam:GetGroup",
+      "iam:CreateAccessKey",
     ]
-
     resources = ["*"]
   }
 } 

--- a/aws/ecr.tf
+++ b/aws/ecr.tf
@@ -2,11 +2,6 @@ resource "aws_iam_user" "hubploy_ecr_user" {
   name = "${var.cluster_name}-hubploy-ecr-pusher"
 }
 
-resource "aws_iam_user_policy_attachment" "hubploy_ecr_image_pusher_policy_attachment" {
-  user = aws_iam_user.hubploy_ecr_user.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
-}
-
 # FIXME: UHHHHHHHH, WHAT DOES THIS MEAN FOR OUR STATE FILES?!
 # FIXME: WE SHOULD DEFINITELY MAYBE PUT A PGP KEY IN HERE
 resource "aws_iam_access_key" "hubploy_ecr_user_secret_key" {

--- a/aws/file-output.tf
+++ b/aws/file-output.tf
@@ -1,21 +1,3 @@
-resource "local_file" "hubploy_ecr_user_creds" {
-  filename = "aws-ecr-creds.cfg"
-  content = <<EOF
-[default]
-aws_access_key_id = ${aws_iam_access_key.hubploy_ecr_user_secret_key.id}
-aws_secret_access_key = ${aws_iam_access_key.hubploy_ecr_user_secret_key.secret}
-EOF
-}
-
-resource "local_file" "hubploy_eks_user_creds" {
-  filename = "aws-eks-creds.cfg"
-  content = <<EOF
-[default]
-aws_access_key_id = ${aws_iam_access_key.hubploy_eks_user_secret_key.id}
-aws_secret_access_key = ${aws_iam_access_key.hubploy_eks_user_secret_key.secret}
-EOF
-}
-
 resource "local_file" "hubploy_yaml" {
   filename = "hubploy.yaml"
   content = <<EOF
@@ -26,15 +8,15 @@ images:
     provider: aws
     aws:
       zone: ${var.region}
-      service_key: aws-ecr-creds.cfg
-      project: # FILL ME IN FOR NOW
+      service_key: # FIXME: Use role assumpmtions when hubploy supports them
+      project: ${data.aws_caller_identity.current.account_id}
 
 
 cluster:
   provider: aws
   aws:
       zone: ${var.region}
-      service_key: aws-eks-creds.cfg
+      service_key: # FIXME: Use role assumpmtions when hubploy supports them
       cluster: ${module.eks.cluster_id}
 EOF
 }

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -1,0 +1,87 @@
+# Attached to deployers group to let them assume the role we need
+data "aws_iam_policy_document" "hubploy_deployers" {
+  statement {
+    sid = "1"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = [
+        aws_iam_role.hubploy_eks.arn
+        #aws_iam_role.hubploy_ecr.arn
+    ]
+  }
+}
+
+# Attached to group
+data "aws_iam_policy_document" "hubploy_eks" {
+    statement {
+        sid = "1"
+        actions = [
+            "eks:DescribeCluster"
+        ]
+        resources = [
+            # FIXME: Restrict it to just the EKS cluster we created
+            "*"
+        ]
+    }
+}
+
+# https://stackoverflow.com/questions/34922920/how-can-i-allow-a-group-to-assume-a-role
+data "aws_iam_policy_document" "hubploy_assumptions" {
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = [
+          # Very icky, but see https://stackoverflow.com/questions/34922920/how-can-i-allow-a-group-to-assume-a-role
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+  }
+}
+
+
+
+resource "aws_iam_role" "hubploy_eks" {
+  name = "${var.cluster_name}-hubploy-eks"
+  assume_role_policy = data.aws_iam_policy_document.hubploy_assumptions.json
+}
+
+resource "aws_iam_policy" "hubploy_eks" {
+  name = "${var.cluster_name}-hubploy-eks"
+  description = "Just enough access to get EKS credentials"
+
+  policy = data.aws_iam_policy_document.hubploy_eks.json
+}
+
+resource "aws_iam_role_policy_attachment" "hubploy_eks" {
+  role       = aws_iam_role.hubploy_eks.name
+  policy_arn = aws_iam_policy.hubploy_eks.arn
+}
+
+
+resource "aws_iam_policy" "hubploy_deployers" {
+  name = "${var.cluster_name}-hubploy-deployers"
+
+  policy = data.aws_iam_policy_document.hubploy_deployers.json
+}
+resource "aws_iam_group" "hubploy_deployers" {
+    name = "${var.cluster_name}-hubploy-deployers"
+}
+resource "aws_iam_group_policy_attachment" "hubploy_deployers" {
+  group       = aws_iam_group.hubploy_deployers.name
+  policy_arn = aws_iam_policy.hubploy_deployers.arn
+}
+
+resource "aws_iam_role" "hubploy_ecr" {
+  name = "${var.cluster_name}-hubploy-ecr"
+  assume_role_policy = data.aws_iam_policy_document.hubploy_assumptions.json
+}
+
+resource "aws_iam_role_policy_attachment" "hubploy_ecr_policy_attachment" {
+  role = aws_iam_role.hubploy_ecr.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -6,8 +6,8 @@ data "aws_iam_policy_document" "hubploy_deployers" {
       "sts:AssumeRole",
     ]
     resources = [
-        aws_iam_role.hubploy_eks.arn
-        #aws_iam_role.hubploy_ecr.arn
+        aws_iam_role.hubploy_eks.arn,
+        aws_iam_role.hubploy_ecr.arn
     ]
   }
 }
@@ -83,5 +83,6 @@ resource "aws_iam_role" "hubploy_ecr" {
 
 resource "aws_iam_role_policy_attachment" "hubploy_ecr_policy_attachment" {
   role = aws_iam_role.hubploy_ecr.name
+  # FIXME: Restrict resources to the ECR repository we created
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
 }

--- a/aws/iam.tf
+++ b/aws/iam.tf
@@ -18,11 +18,10 @@ data "aws_iam_policy_document" "hubploy_eks" {
     statement {
         sid = "1"
         actions = [
-            "eks:DescribeCluster"
+          "eks:DescribeCluster"
         ]
         resources = [
-            # FIXME: Restrict it to just the EKS cluster we created
-            "*"
+          module.eks.cluster_arn
         ]
     }
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -80,7 +80,7 @@ module "eks" {
       max_capacity     = 3
       min_capacity     = 1
 
-      instance_type = "t3.micro"
+      instance_type = "t3.small"
       k8s_labels    = {
         "hub.jupyter.org/node-purpose" =  "core"
       }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -102,16 +102,16 @@ module "eks" {
   }
 
 
-  map_roles    = var.map_roles
   map_accounts = var.map_accounts
+  map_users = var.map_users
 
 
-  # map_users = concat([{
-  #   userarn  = aws_iam_user.hubploy_eks_user.arn
-  #   username  = aws_iam_user.hubploy_eks_user.name
-  #   # FIXME: Narrow these permissions down?
-  #   groups   = ["system:masters"]
-  # }], var.map_users)
+  map_roles = concat([{
+    rolearn  = aws_iam_role.hubploy_eks.arn
+    username = aws_iam_role.hubploy_eks.name
+    # FIXME: Narrow these permissions down?
+    groups   = ["system:masters"]
+  }], var.map_roles)
 }
 
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -19,6 +19,8 @@ data "aws_eks_cluster_auth" "cluster" {
   name = module.eks.cluster_id
 }
 
+data "aws_caller_identity" "current" {}
+
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
@@ -104,47 +106,12 @@ module "eks" {
   map_accounts = var.map_accounts
 
 
-  map_users = concat([{
-    userarn  = aws_iam_user.hubploy_eks_user.arn
-    username  = aws_iam_user.hubploy_eks_user.name
-    # FIXME: Narrow these permissions down?
-    groups   = ["system:masters"]
-  }], var.map_users)
-}
-
-resource "aws_iam_user" "hubploy_eks_user" {
-  name = "${var.cluster_name}-hubploy-eks"
-}
-
-resource "aws_iam_policy" "hubploy_eks_policy" {
-  name = "${var.cluster_name}-hubploy-eks"
-  description = "Just enough access to get EKS credentials"
-
-  # FIXME: restrict this to just the EKS cluster we created
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-      {
-          "Sid": "VisualEditor0",
-          "Effect": "Allow",
-          "Action": "eks:DescribeCluster",
-          "Resource": "*"
-      }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_user_policy_attachment" "hubploy_eks_user_policy_attachment" {
-  user = aws_iam_user.hubploy_eks_user.name
-  policy_arn = aws_iam_policy.hubploy_eks_policy.arn
-}
-
-# FIXME: UHHHHHHHH, WHAT DOES THIS MEAN FOR OUR STATE FILES?!
-# FIXME: WE SHOULD DEFINITELY MAYBE PUT A PGP KEY IN HERE
-resource "aws_iam_access_key" "hubploy_eks_user_secret_key" {
-  user = aws_iam_user.hubploy_eks_user.name
+  # map_users = concat([{
+  #   userarn  = aws_iam_user.hubploy_eks_user.arn
+  #   username  = aws_iam_user.hubploy_eks_user.name
+  #   # FIXME: Narrow these permissions down?
+  #   groups   = ["system:masters"]
+  # }], var.map_users)
 }
 
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -78,7 +78,7 @@ module "eks" {
       max_capacity     = 3
       min_capacity     = 1
 
-      instance_type = "t3.micro"
+      instance_type = "t3.small"
       k8s_labels    = {
         "hub.jupyter.org/node-purpose" =  "core"
       }


### PR DESCRIPTION
This is a fork from https://github.com/yuvipanda/terraform-deploy/tree/fix/no-users and the idea is that you can `terraform apply` from the `aws-creds` folder to create a group that may assume a role from which you may then run the real terraform script from the `aws` folder. You simply add yourself to the group and then use awsudo or sts to assume the role in a shell before creating your EKS cluster. Looking for direction here, I took a lot of liberties and I want to gauge interest in adopting this system for other orgs.