### PR TITLE
[WIP] Add optional private subnets

### DIFF
--- a/aws/efs.tf
+++ b/aws/efs.tf
@@ -11,9 +11,7 @@ resource "aws_security_group" "home_dirs_sg" {
 
   # NFS
   ingress {
-
-    # FIXME: Is ther a way to do this without CIDR block copy/pasta
-    cidr_blocks = [ "172.16.0.0/16"]
+    cidr_blocks = [ var.cidr ]
     # FIXME: Do we need this security_groups here along with cidr_blocks
     security_groups = [ module.eks.worker_security_group_id ]
     from_port        = 2049

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -45,7 +45,7 @@ module "vpc" {
   private_subnets      = var.private_subnets
   
   enable_dns_hostnames = true
-  enable_dns_support   = true  # var.use_private_subnets
+  enable_dns_support   = true
   enable_nat_gateway   = var.use_private_subnets
   single_nat_gateway   = var.use_private_subnets
   
@@ -68,7 +68,7 @@ module "eks" {
   source       = "terraform-aws-modules/eks/aws"
   cluster_name = var.cluster_name
   subnets      = var.use_private_subnets ? module.vpc.private_subnets : module.vpc.public_subnets
-  cluster_endpoint_private_access = true # var.use_private_subnets
+  cluster_endpoint_private_access = true
   vpc_id       = module.vpc.vpc_id
   enable_irsa  = true
 
@@ -89,21 +89,18 @@ module "eks" {
         "hub.jupyter.org/node-purpose" =  "core"
       }
       additional_tags = {
-        "Name" : "${var.cluster_name}-core"
       }
     }
     notebook = {
      desired_capacity = 1
      max_capacity     = 10
      min_capacity     = 1
-     # subnets          = var.use_private_subnets ? module.vpc.private_subnets : module.vpc.public_subnets
 
      instance_type = "t3.medium"
      k8s_labels = {
        "hub.jupyter.org/node-purpose" =  "user"
      }
      additional_tags = {
-        "Name" :  "${var.cluster_name}-user"
      }
     }
   }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -35,3 +35,27 @@ variable "map_users" {
   default = [
   ]
 }
+
+variable "use_private_subnets" {
+    description = "Use private subnets for EKS worker nodes."
+    type        = bool
+    default = false
+}
+
+variable "public_subnets" {  
+    description = "Public subnet IP ranges."
+    type        = list(string)
+    default = ["172.16.1.0/24", "172.16.2.0/24", "172.16.3.0/24"]
+}
+
+variable "private_subnets" {  
+    description = "Private subnet IP ranges."
+    type        = list(string)
+    default = []   #   ["172.16.4.0/24", "172.16.5.0/24", "172.16.6.0/24"]
+}
+
+variable "cidr" {
+    description = "IP range of subnets"
+    type = string
+    default = "172.16.0.0/16"
+}


### PR DESCRIPTION
Addresses issue #32.   STScI is still doing more testing but this is our work so far.   I wanted to post this while this is fresh in your minds.

Adds 4 variables to enable optional use of configurable private subnets:

var.use_private_subnets  
var.private_subnets
var.public_subnets
var.cidr

Defaults are set for public subnets. 

This also switches core nodes to t3.small which I recall as needed to avoid deployment or hub failures.    That's unrelated and can be removed if it's a problem...  but we find it necessary. 