### PR TITLE
Use hashicorp/setup-terraform GH action

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,22 +1,35 @@
 name: Validate Terraform
 on:
   - pull_request
+
 jobs:
   terraform:
-    name: 'Terraform'
+    name: terraform
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./aws
+
     steps:
-      - name: 'Checkout'
-        uses: actions/checkout@master
-      - name: 'Terraform Init'
-        uses: hashicorp/terraform-github-actions@master
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
         with:
-          tf_actions_version: 0.12.13
-          tf_actions_subcommand: 'init'
-          tf_actions_working_dir: 'aws'
-      - name: 'Terraform Validate'
-        uses: hashicorp/terraform-github-actions@master
-        with:
-          tf_actions_version: 0.12.13
-          tf_actions_subcommand: 'validate'
-          tf_actions_working_dir: 'aws'
+          terraform_version: 0.12.29
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color


### PR DESCRIPTION
`hashicorp/terraform-github-actions` GitHub action is no longer maintained, and has been superseded by the `hashicorp/setup-terraform` GitHub action.